### PR TITLE
Set up firebase admin sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+solitude-credentials.json

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>Solitude-admin</name>
 	<description>admin serverless spring boot project</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>8</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -60,6 +60,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+		  <groupId>com.google.firebase</groupId>
+		  <artifactId>firebase-admin</artifactId>
+		  <version>7.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/Solitude/Configuration/FirebaseConfig.java
+++ b/src/main/java/com/Solitude/Configuration/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package com.Solitude.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+	 @PostConstruct
+    public void init() {
+
+        FileInputStream serviceAccount;
+        try {
+            serviceAccount = new FileInputStream("solitude-credentials.json");
+
+
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .setDatabaseUrl("https://solitude-478ad.firebaseio.com")
+                    .build();
+
+            FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);
+
+
+            System.out.println(firebaseApp);
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
+spring.datasource.hikari.connectionTimeout=20000
+spring.datasource.hikari.maximumPoolSize=5
 
+## PostgreSQL
+spring.datasource.url=jdbc:postgresql://ec2-54-225-190-241.compute-1.amazonaws.com:5432/dcrfvlnefcckvg
+spring.datasource.username=gnzgdwhxrviksl
+spring.datasource.password=a85de4b8faaa48447b51eef789915e43828e5f97d0182a3f0fb7989b22fa13a3
+
+#drop n create table again, good for testing, comment this in production
+spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
Kind of incomplete since there are APIs defined yet.

In the APIs, the following code has to be added to check for authentication

```java
   @RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
    public ResponseEntity<String> get(@RequestHeader("token") String idToken) throws FirebaseAuthException {
        try {
        	FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
            String uid = decodedToken.getUid();
            return new ResponseEntity<>(uid, HttpStatus.OK);
        } catch(Exception e) {
            logger.error("Internal error {} ", e.getMessage());
            e.printStackTrace();
            return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
        }
        
    }
```

This requires the service-accounts json file from firebase for it to run. The file should be renamed to `solitude-credentials.json` and placed at the root of the repository.

The client should send the header `token` with the current user's *idToken* for requests that need to be authenticated.